### PR TITLE
[feat] 시간 측정을 위한 AOP 작성 및 RestTemplate timeout 30으로 늘림

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/src/main/java/com/example/front/annotation/CalculateTime.java
+++ b/src/main/java/com/example/front/annotation/CalculateTime.java
@@ -1,0 +1,11 @@
+package com.example.front.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CalculateTime {
+}

--- a/src/main/java/com/example/front/aspect/TimeCalculateAspect.java
+++ b/src/main/java/com/example/front/aspect/TimeCalculateAspect.java
@@ -1,0 +1,26 @@
+package com.example.front.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class TimeCalculateAspect {
+    @Around("@annotation(com.example.front.annotation.CalculateTime)")
+    public Object calculateTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+
+        Object result = joinPoint.proceed();
+
+        long endTime = System.currentTimeMillis();
+        long elapsedTime = endTime - startTime;
+
+        log.info("AI서버와 통신하는데 걸린 시간 : {}ms", elapsedTime);
+
+        return result;
+    }
+}

--- a/src/main/java/com/example/front/aspect/TimeCalculateAspect.java
+++ b/src/main/java/com/example/front/aspect/TimeCalculateAspect.java
@@ -14,13 +14,13 @@ public class TimeCalculateAspect {
     public Object calculateTime(ProceedingJoinPoint joinPoint) throws Throwable {
         long startTime = System.currentTimeMillis();
 
-        Object result = joinPoint.proceed();
-
-        long endTime = System.currentTimeMillis();
-        long elapsedTime = endTime - startTime;
-
-        log.info("AI서버와 통신하는데 걸린 시간 : {}ms", elapsedTime);
-
-        return result;
+        try {
+            return joinPoint.proceed();
+        } finally {
+            long endTime = System.currentTimeMillis();
+            long elapsedTime = endTime - startTime;
+            String methodName = joinPoint.getSignature().getDeclaringTypeName() + "." + joinPoint.getSignature().getName();
+            log.info("{}메서드 실행 시간 : {}ms", methodName, elapsedTime);
+        }
     }
 }

--- a/src/main/java/com/example/front/config/WebClientConfig.java
+++ b/src/main/java/com/example/front/config/WebClientConfig.java
@@ -12,8 +12,8 @@ public class WebClientConfig {
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder
-                .connectTimeout(Duration.ofSeconds(3L))
-                .readTimeout(Duration.ofSeconds(3L))
+                .connectTimeout(Duration.ofSeconds(30L))
+                .readTimeout(Duration.ofSeconds(30L))
                 .build();
     }
 }

--- a/src/main/java/com/example/front/file/adaptor/FileAdaptor.java
+++ b/src/main/java/com/example/front/file/adaptor/FileAdaptor.java
@@ -1,5 +1,6 @@
 package com.example.front.file.adaptor;
 
+import com.example.front.annotation.CalculateTime;
 import com.example.front.config.BackAdaptorProperties;
 import com.example.front.file.dto.response.ResponseDto;
 import com.example.front.file.exception.AiServerCommunicationException;
@@ -24,6 +25,7 @@ public class FileAdaptor {
     private static final String SCHEME = "http://";
     private static final String URL = "/predict";
 
+    @CalculateTime
     public ResponseDto communicateWithAiServer(List<MultipartFile> files) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #26 

## 📝작업 내용

> 시간 측정을 위한 AOP 작성 및 RestTemplate timeout 30으로 늘림

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 일부 주요 작업의 실행 시간을 모니터링할 수 있는 기능이 추가되어, 시스템 성능 추적이 용이해졌습니다.
	- 네트워크 통신 시 연결 및 응답 대기 시간이 연장되어, 지연 상황에서도 보다 안정적인 서비스를 제공합니다.
	- 새로운 주석 `@CalculateTime`이 추가되어 특정 메서드의 실행 시간을 기록할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->