### PR TITLE
[feat] readTimout 600 으로 수정

### DIFF
--- a/src/main/java/com/example/front/config/WebClientConfig.java
+++ b/src/main/java/com/example/front/config/WebClientConfig.java
@@ -12,8 +12,8 @@ public class WebClientConfig {
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder
-                .connectTimeout(Duration.ofSeconds(30L))
-                .readTimeout(Duration.ofSeconds(30L))
+                .connectTimeout(Duration.ofSeconds(3L))
+                .readTimeout(Duration.ofSeconds(600L))
                 .build();
     }
 }

--- a/src/main/java/com/example/front/file/adaptor/FileAdaptor.java
+++ b/src/main/java/com/example/front/file/adaptor/FileAdaptor.java
@@ -14,6 +14,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
+
 import java.net.URI;
 import java.util.List;
 
@@ -54,7 +55,7 @@ public class FileAdaptor {
                 ResponseDto.class
         );
 
-        if (exchange.getStatusCode() != HttpStatus.ACCEPTED) {
+        if (exchange.getStatusCode() != HttpStatus.OK) {
             throw new AiServerCommunicationException("AI 서버와의 통신 실패: 응답 코드" + exchange.getStatusCode() + ", 본문: " + exchange.getBody(), null);
         }
 

--- a/src/main/java/com/example/front/home/controller/HomeController.java
+++ b/src/main/java/com/example/front/home/controller/HomeController.java
@@ -27,6 +27,6 @@ public class HomeController {
     public String upload(@RequestParam("files") List<MultipartFile> files, Model model) {
         model.addAttribute("result", fileService.communicateWithAiServer(files));
 
-        return "user/result";
+        return "user/result1";
     }
 }

--- a/src/main/resources/templates/user/result1.html
+++ b/src/main/resources/templates/user/result1.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{common/layout/layout}"
+      layout:fragment="content">
+
+<body>
+<div>
+    <p th:text="${result}"></p>
+</div>
+</body>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용

> readTimout 600 으로 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - 애플리케이션의 네트워크 통신 타임아웃 설정이 조정되어, 보다 빠른 연결 시도와 안정적인 응답 처리가 가능해졌습니다.
- **Bug Fixes**
  - AI 서버와의 통신에서 오류 처리 로직이 개선되어, 성공적인 응답이 아닐 경우 더 넓은 범위의 오류를 감지할 수 있게 되었습니다.
- **New Features**
  - 파일 업로드 후 새로운 결과 페이지(`result1.html`)가 추가되어, 동적 콘텐츠 렌더링이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->