### PR TITLE
로그문 수정 및 통신 소요시간 측정 로그 추가

### DIFF
--- a/src/main/java/com/example/front/file/adaptor/AsyncFileAdaptor.java
+++ b/src/main/java/com/example/front/file/adaptor/AsyncFileAdaptor.java
@@ -38,8 +38,6 @@ public class AsyncFileAdaptor {
         body.add("webhook_url", backAdaptorProperties.getWebhookUrl());
         body.add("taskId", taskId);
 
-        log.info("webhook_url : {}", backAdaptorProperties.getWebhookUrl());
-
         try {
             for (MultipartFile file : files) {
                 body.add("image", new ByteArrayResource(file.getBytes()) {

--- a/src/main/java/com/example/front/file/adaptor/AsyncFileAdaptor.java
+++ b/src/main/java/com/example/front/file/adaptor/AsyncFileAdaptor.java
@@ -1,5 +1,6 @@
 package com.example.front.file.adaptor;
 
+import com.example.front.annotation.CalculateTime;
 import com.example.front.config.BackAdaptorProperties;
 import com.example.front.file.exception.AiServerCommunicationException;
 import com.example.front.file.exception.UnExpectedStateException;
@@ -28,6 +29,7 @@ public class AsyncFileAdaptor {
     private static final String SCHEME = "http://";
     private static final String URL = "/predict";
 
+    @CalculateTime
     public void communicateWithAiServer(List<MultipartFile> files, String taskId) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);

--- a/src/main/java/com/example/front/webhook/controller/RestWebhookController.java
+++ b/src/main/java/com/example/front/webhook/controller/RestWebhookController.java
@@ -29,7 +29,7 @@ public class RestWebhookController {
         }
 
         sseRestController.sendResult(taskId, result.toString());
-        log.info("결과 전송 완료: {}", result);
+        log.info("결과 전송 완료: \n{}", result);
 
         return ResponseEntity.ok("결과 전송 완료");
     }

--- a/src/test/java/com/example/front/file/adaptor/SyncFileAdaptorTest.java
+++ b/src/test/java/com/example/front/file/adaptor/SyncFileAdaptorTest.java
@@ -1,0 +1,79 @@
+package com.example.front.file.adaptor;
+
+import com.example.front.config.BackAdaptorProperties;
+import com.example.front.file.dto.response.ResponseDto;
+import com.example.front.file.exception.AiServerCommunicationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SyncFileAdaptorTest {
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private BackAdaptorProperties backAdaptorProperties;
+
+    @InjectMocks
+    private SyncFileAdaptor syncFileAdaptor;
+
+    @Test
+    void communicateWithAiServer_returnResponseDto_whenRequestIsSuccessful() {
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "image", "test.png", "image/png", "img-data".getBytes());
+        List<MultipartFile> files = List.of(mockFile);
+
+        URI uri = URI.create("http://localhost/predict");
+        when(backAdaptorProperties.getAddress()).thenReturn("localhost");
+
+        ResponseDto fakeResponse = new ResponseDto();
+        ResponseEntity<ResponseDto> responseEntity = new ResponseEntity<>(fakeResponse, HttpStatus.OK);
+        when(restTemplate.exchange(
+                eq(uri),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(ResponseDto.class)
+        )).thenReturn(responseEntity);
+
+        ResponseDto result = syncFileAdaptor.communicateWithAiServer(files);
+
+        assertEquals(fakeResponse, result);
+    }
+
+    @Test
+    void communicateWithServer_throwAiServerCommunicationException_whenAiServerDoesntReturnHttpStatusCode200() {
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "image", "test.png", "image/png", "img-data".getBytes());
+        List<MultipartFile> files = List.of(mockFile);
+
+        when(backAdaptorProperties.getAddress()).thenReturn("localhost");
+
+        ResponseEntity<ResponseDto> responseEntity = new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
+        when(restTemplate.exchange(
+                any(),
+                any(),
+                any(),
+                eq(ResponseDto.class)
+        )).thenReturn(responseEntity);
+
+        assertThrows(AiServerCommunicationException.class, () -> syncFileAdaptor.communicateWithAiServer(files));
+    }
+}

--- a/src/test/java/com/example/front/file/utils/FileUtilsTest.java
+++ b/src/test/java/com/example/front/file/utils/FileUtilsTest.java
@@ -1,0 +1,51 @@
+package com.example.front.file.utils;
+
+import com.example.front.config.FileProperties;
+import com.example.front.file.exception.FileEmptyException;
+import org.apache.tika.Tika;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class FileUtilsTest {
+    @Mock
+    private FileProperties fileProperties;
+    @InjectMocks
+    private FileUtils fileUtils;
+
+    @Test
+    void validMimeType_returnTrue_whenMimeTypeIsSupported() throws IOException {
+        MultipartFile mockFile = new MockMultipartFile("file", "test.png", "image/png", new byte[10]);
+        Tika tika = mock(Tika.class);
+        ReflectionTestUtils.setField(fileUtils, "tika", tika);
+
+        when(tika.detect(any(InputStream.class))).thenReturn("image/png");
+        when(fileProperties.getSupportedTypes()).thenReturn(Set.of("image/png"));
+
+        assertTrue(fileUtils.isValidMimeType(mockFile));
+    }
+
+    @Test
+    void throwFileEmptyException_whenFileIsEmpty() {
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.isEmpty()).thenReturn(true);
+
+        assertThrows(FileEmptyException.class, () -> fileUtils.isValidMimeType(mockFile));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

> 로그문 수정 및 통신 소요시간 측정 로그 추가
> webhook_url 노출 우려로 해당 로그 삭제
> SyncFileAdaptor 에만 시간측정 어노테이션 달려있던걸 AsyncFileAdaptor에도 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 로그 출력 형식이 개선되어 결과 객체가 여러 줄로 더 읽기 쉽게 표시됩니다.

- **기타**
  - 내부 메서드에 실행 시간 측정 기능이 추가되었습니다.

- **테스트**
  - AI 서버와의 통신 성공 및 실패 시나리오를 검증하는 테스트가 추가되었습니다.
  - 파일 MIME 타입 유효성 검사 및 빈 파일 처리에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->