### PR TITLE
Redis 에 조회수 저장 매일 00시에 DB 로 옮기는 작업

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -104,12 +104,12 @@ jobs:
           script: |
             echo "AI_MODEL_SERVER=${{ secrets.AI_MODEL_SERVER_ADDRESS }}" > /home/${{ secrets.EC2_USERNAME }}/.env
             echo "WEBHOOK_URL=${{ secrets.WEBHOOK_URL }}" >> /home/${{ secrets.EC2_USERNAME }}/.env
-            echo "WEBHOOK_URL=${{ secrets.REDIS_HOST }}" >> /home/${{ secrets.REDIS_HOST }}/.env
-            echo "WEBHOOK_URL=${{ secrets.REDIS_PORT }}" >> /home/${{ secrets.REDIS_PORT }}/.env
-            echo "WEBHOOK_URL=${{ secrets.DB_HOST }}" >> /home/${{ secrets.DB_HOST }}/.env
-            echo "WEBHOOK_URL=${{ secrets.DB_PORT }}" >> /home/${{ secrets.DB_PORT }}/.env
-            echo "WEBHOOK_URL=${{ secrets.DB_USER_NAME }}" >> /home/${{ secrets.DB_USER_NAME }}/.env
-            echo "WEBHOOK_URL=${{ secrets.DB_PASSWORD }}" >> /home/${{ secrets.DB_PASSWORD }}/.env
+            echo "REDIS_HOST=${{ secrets.REDIS_HOST }}" >> /home/${{ secrets.REDIS_HOST }}/.env
+            echo "REDIS_PORT=${{ secrets.REDIS_PORT }}" >> /home/${{ secrets.REDIS_PORT }}/.env
+            echo "DB_HOST=${{ secrets.DB_HOST }}" >> /home/${{ secrets.DB_HOST }}/.env
+            echo "DB_PORT=${{ secrets.DB_PORT }}" >> /home/${{ secrets.DB_PORT }}/.env
+            echo "DB_USER_NAME=${{ secrets.DB_USER_NAME }}" >> /home/${{ secrets.DB_USER_NAME }}/.env
+            echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> /home/${{ secrets.DB_PASSWORD }}/.env
             
             sudo docker stop front || true
             sudo docker rm front || true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,6 +18,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      REDIS_HOST: ${{ secrets.REDIS_HOST }}
+      REDIS_PORT: ${{ secrets.REDIS_PORT }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_USER_NAME: ${{ secrets.DB_USER_NAME }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
     steps:
     - uses: actions/checkout@v4
@@ -30,10 +37,9 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
+    # Redis 세팅
     - name: Start Redis
       uses: supercharge/redis-github-action@1.1.0
-      with:
-        redis-version: 6
 
     # 패키징
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -104,6 +104,12 @@ jobs:
           script: |
             echo "AI_MODEL_SERVER=${{ secrets.AI_MODEL_SERVER_ADDRESS }}" > /home/${{ secrets.EC2_USERNAME }}/.env
             echo "WEBHOOK_URL=${{ secrets.WEBHOOK_URL }}" >> /home/${{ secrets.EC2_USERNAME }}/.env
+            echo "WEBHOOK_URL=${{ secrets.REDIS_HOST }}" >> /home/${{ secrets.REDIS_HOST }}/.env
+            echo "WEBHOOK_URL=${{ secrets.REDIS_PORT }}" >> /home/${{ secrets.REDIS_PORT }}/.env
+            echo "WEBHOOK_URL=${{ secrets.DB_HOST }}" >> /home/${{ secrets.DB_HOST }}/.env
+            echo "WEBHOOK_URL=${{ secrets.DB_PORT }}" >> /home/${{ secrets.DB_PORT }}/.env
+            echo "WEBHOOK_URL=${{ secrets.DB_USER_NAME }}" >> /home/${{ secrets.DB_USER_NAME }}/.env
+            echo "WEBHOOK_URL=${{ secrets.DB_PASSWORD }}" >> /home/${{ secrets.DB_PASSWORD }}/.env
             
             sudo docker stop front || true
             sudo docker rm front || true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -104,12 +104,12 @@ jobs:
           script: |
             echo "AI_MODEL_SERVER=${{ secrets.AI_MODEL_SERVER_ADDRESS }}" > /home/${{ secrets.EC2_USERNAME }}/.env
             echo "WEBHOOK_URL=${{ secrets.WEBHOOK_URL }}" >> /home/${{ secrets.EC2_USERNAME }}/.env
-            echo "REDIS_HOST=${{ secrets.REDIS_HOST }}" >> /home/${{ secrets.REDIS_HOST }}/.env
-            echo "REDIS_PORT=${{ secrets.REDIS_PORT }}" >> /home/${{ secrets.REDIS_PORT }}/.env
-            echo "DB_HOST=${{ secrets.DB_HOST }}" >> /home/${{ secrets.DB_HOST }}/.env
-            echo "DB_PORT=${{ secrets.DB_PORT }}" >> /home/${{ secrets.DB_PORT }}/.env
-            echo "DB_USER_NAME=${{ secrets.DB_USER_NAME }}" >> /home/${{ secrets.DB_USER_NAME }}/.env
-            echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> /home/${{ secrets.DB_PASSWORD }}/.env
+            echo "REDIS_HOST=${{ secrets.REDIS_HOST }}" >> /home/${{ secrets.EC2_USERNAME }}/.env
+            echo "REDIS_PORT=${{ secrets.REDIS_PORT }}" >> /home/${{ secrets.EC2_USERNAME }}/.env
+            echo "DB_HOST=${{ secrets.DB_HOST }}" >> /home/${{ secrets.EC2_USERNAME }}/.env
+            echo "DB_PORT=${{ secrets.DB_PORT }}" >> /home/${{ secrets.EC2_USERNAME }}/.env
+            echo "DB_USER_NAME=${{ secrets.DB_USER_NAME }}" >> /home/${{ secrets.EC2_USERNAME }}/.env
+            echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> /home/${{ secrets.EC2_USERNAME }}/.env
             
             sudo docker stop front || true
             sudo docker rm front || true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,6 +30,11 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
+    - name: Start Redis
+      uses: supercharge/redis-github-action@1.1.0
+      with:
+        redis-version: 6
+
     # 패키징
     - name: Build with Maven
       run: mvn -B package --file pom.xml
@@ -48,7 +53,7 @@ jobs:
     # 도커 이미지 푸시
     - name: push Docker image
       run: docker push damho/front
-      
+
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -116,7 +116,7 @@ jobs:
             sudo docker rmi damho/front:latest || true
             
             sudo docker pull damho/front:latest
-            sudo docker run --env-file .env -d -p 8080:8080 --name front --network dockernetwork damho/front:latest 
+            sudo docker run -e TZ=Asia/Seoul --env-file .env -d -p 8080:8080 --name front --network dockernetwork damho/front:latest 
 
       # 작업 완료 후 보안 그룹에서 GitHub Actions 워커의 IP 제거
       - name: Remove GitHub Actions Runner IP from Security Group

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,6 +37,10 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
+    # MySQL 세팅
+    - name: Start MySQL
+      uses: samin/mysql-action@v1
+
     # Redis 세팅
     - name: Start Redis
       uses: supercharge/redis-github-action@1.1.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 	<description>프론트 서버</description>
 	<properties>
 		<java.version>17</java.version>
+		<netty.version>4.1.119.Final</netty.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -53,6 +54,12 @@
 			<groupId>nz.net.ultraq.thymeleaf</groupId>
 			<artifactId>thymeleaf-layout-dialect</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,16 @@
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/main/java/com/example/front/FrontApplication.java
+++ b/src/main/java/com/example/front/FrontApplication.java
@@ -3,9 +3,11 @@ package com.example.front;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableScheduling
 public class FrontApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/front/config/RedisConfig.java
+++ b/src/main/java/com/example/front/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.example.front.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(RedisProperties.class)
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/front/config/RedisProperties.java
+++ b/src/main/java/com/example/front/config/RedisProperties.java
@@ -1,0 +1,15 @@
+package com.example.front.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "spring.data.redis")
+public class RedisProperties {
+    private String host;
+    private int port;
+}

--- a/src/main/java/com/example/front/home/controller/HomeController.java
+++ b/src/main/java/com/example/front/home/controller/HomeController.java
@@ -48,6 +48,7 @@ public class HomeController {
                          @RequestParam("selectedCarPart") CarPart carPart,
                          Model model) {
         String result = fileService.communicateWithAiServer(files, carPart);
+        pageViewCountService.incrementViewCount(PageType.RESULT);
 
         if (isSyncMode()) {
             model.addAttribute("result", result);
@@ -56,8 +57,6 @@ public class HomeController {
             model.addAttribute("taskId", result);
             return "user/result_async";
         }
-
-        pageViewCountService.incrementViewCount(PageType.RESULT);
 
         throw new IllegalStateException("앱 모드 설정을 확인해주세요.");
     }

--- a/src/main/java/com/example/front/home/controller/HomeController.java
+++ b/src/main/java/com/example/front/home/controller/HomeController.java
@@ -2,6 +2,8 @@ package com.example.front.home.controller;
 
 import com.example.front.annotation.CalculateTime;
 import com.example.front.file.service.FileService;
+import com.example.front.pageview.entity.PageType;
+import com.example.front.pageview.service.PageViewCountService;
 import com.example.front.part.domain.CarPart;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,15 +25,19 @@ public class HomeController {
     private String appMode;
 
     private final FileService fileService;
+    private final PageViewCountService pageViewCountService;
 
     @GetMapping("/")
     public String home() {
+        pageViewCountService.incrementViewCount(PageType.HOME);
+
         return "user/home";
     }
 
     @GetMapping("/request")
     public String getRequestPage(Model model) {
         model.addAttribute("carParts", CarPart.values());
+        pageViewCountService.incrementViewCount(PageType.REQUEST);
 
         return "user/request";
     }
@@ -50,6 +56,8 @@ public class HomeController {
             model.addAttribute("taskId", result);
             return "user/result_async";
         }
+
+        pageViewCountService.incrementViewCount(PageType.RESULT);
 
         throw new IllegalStateException("앱 모드 설정을 확인해주세요.");
     }

--- a/src/main/java/com/example/front/pageview/controller/PageViewRestController.java
+++ b/src/main/java/com/example/front/pageview/controller/PageViewRestController.java
@@ -1,0 +1,21 @@
+package com.example.front.pageview.controller;
+
+import com.example.front.pageview.dto.response.PageViewGetResponse;
+import com.example.front.pageview.service.PageViewCountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/pageview")
+@RequiredArgsConstructor
+public class PageViewRestController {
+    private final PageViewCountService pageViewCountService;
+
+    @GetMapping()
+    public List<PageViewGetResponse> getPageViewCount(@RequestParam LocalDate date) {
+        return pageViewCountService.getPageViewByDate(date);
+    }
+}

--- a/src/main/java/com/example/front/pageview/dto/response/PageViewGetResponse.java
+++ b/src/main/java/com/example/front/pageview/dto/response/PageViewGetResponse.java
@@ -1,0 +1,15 @@
+package com.example.front.pageview.dto.response;
+
+import com.example.front.pageview.entity.PageType;
+
+import java.time.LocalDate;
+
+public interface PageViewGetResponse {
+    PkInfo getPk();
+    Long getViewCount();
+
+    interface PkInfo {
+        LocalDate getViewDate();
+        PageType getPageType();
+    }
+}

--- a/src/main/java/com/example/front/pageview/entity/PageType.java
+++ b/src/main/java/com/example/front/pageview/entity/PageType.java
@@ -1,0 +1,25 @@
+package com.example.front.pageview.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum PageType {
+    HOME("home"),
+    REQUEST("request"),
+    RESULT("result");
+
+    private final String value;
+
+    PageType(String value) {
+        this.value = value;
+    }
+
+    public static PageType fromValue(String value) {
+        for (PageType pageType : PageType.values()) {
+            if (pageType.getValue().equals(value)) {
+                return pageType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown value: " + value);
+    }
+}

--- a/src/main/java/com/example/front/pageview/entity/PageTypeConverter.java
+++ b/src/main/java/com/example/front/pageview/entity/PageTypeConverter.java
@@ -1,0 +1,17 @@
+package com.example.front.pageview.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class PageTypeConverter implements AttributeConverter<PageType, String> {
+    @Override
+    public String convertToDatabaseColumn(PageType attribute) {
+        return attribute == null ? null : attribute.getValue();
+    }
+
+    @Override
+    public PageType convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : PageType.fromValue(dbData);
+    }
+}

--- a/src/main/java/com/example/front/pageview/entity/PageView.java
+++ b/src/main/java/com/example/front/pageview/entity/PageView.java
@@ -34,4 +34,8 @@ public class PageView {
         @Column(name = "page_id", length = 50)
         private PageType pageType;
     }
+
+    public void updateViewCount(long viewCount) {
+        this.viewCount = viewCount;
+    }
 }

--- a/src/main/java/com/example/front/pageview/entity/PageView.java
+++ b/src/main/java/com/example/front/pageview/entity/PageView.java
@@ -1,0 +1,36 @@
+package com.example.front.pageview.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "page_views")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PageView {
+    @EmbeddedId
+    private Pk pk;
+
+    @Column(name = "view_count")
+    private Long viewCount;
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    @Embeddable
+    public static class Pk implements Serializable {
+        @Column(name = "view_date")
+        private LocalDate viewDate;
+
+        @Convert(converter = PageTypeConverter.class)
+        @Column(name = "page_id", length = 50)
+        private PageType pageType;
+    }
+}

--- a/src/main/java/com/example/front/pageview/entity/PageView.java
+++ b/src/main/java/com/example/front/pageview/entity/PageView.java
@@ -25,6 +25,7 @@ public class PageView {
     @AllArgsConstructor
     @EqualsAndHashCode
     @Embeddable
+    @Getter
     public static class Pk implements Serializable {
         @Column(name = "view_date")
         private LocalDate viewDate;

--- a/src/main/java/com/example/front/pageview/repository/PageViewCountRepository.java
+++ b/src/main/java/com/example/front/pageview/repository/PageViewCountRepository.java
@@ -1,0 +1,11 @@
+package com.example.front.pageview.repository;
+
+import com.example.front.pageview.entity.PageType;
+import com.example.front.pageview.entity.PageView;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface PageViewCountRepository extends JpaRepository<PageView, PageView.Pk> {
+    void saveOrUpdate(LocalDate date, PageType pageType, Long viewCount);
+}

--- a/src/main/java/com/example/front/pageview/repository/PageViewCountRepository.java
+++ b/src/main/java/com/example/front/pageview/repository/PageViewCountRepository.java
@@ -1,7 +1,12 @@
 package com.example.front.pageview.repository;
 
+import com.example.front.pageview.dto.response.PageViewGetResponse;
 import com.example.front.pageview.entity.PageView;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface PageViewCountRepository extends JpaRepository<PageView, PageView.Pk> {
+    List<PageViewGetResponse> findByPk_ViewDate(LocalDate date);
 }

--- a/src/main/java/com/example/front/pageview/repository/PageViewCountRepository.java
+++ b/src/main/java/com/example/front/pageview/repository/PageViewCountRepository.java
@@ -1,11 +1,7 @@
 package com.example.front.pageview.repository;
 
-import com.example.front.pageview.entity.PageType;
 import com.example.front.pageview.entity.PageView;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
-
 public interface PageViewCountRepository extends JpaRepository<PageView, PageView.Pk> {
-    void saveOrUpdate(LocalDate date, PageType pageType, Long viewCount);
 }

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -56,7 +56,7 @@ public class PageViewCountScheduler {
                     }
 
                     processedCount++;
-                    log.debug("페이지 타입 {} 처리 완료: {} 조회수", pageType, count);
+                    log.info("페이지 타입 {} 처리 완료: {} 조회수", pageType, count);
                 } catch (Exception e) {
                     failedCount++;
                     log.error("페이지 타입 {} 처리 중 오류 발생: {}", pageType, e.getMessage(), e);

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -21,7 +21,7 @@ public class PageViewCountScheduler {
     private final PageViewCountService pageViewCountService;
     private final PageViewCountRepository pageViewCountRepository;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 10 45 * * *")
     @Transactional
     public void syncViewCountToDB() {
         try {
@@ -49,7 +49,12 @@ public class PageViewCountScheduler {
                         pageViewCountRepository.save(new PageView(pk, count));
                     }
 
-                    pageViewCountService.deleteViewCount(pageType);
+                    if (pageViewCountService.deleteViewCount(pageType)) {
+                        log.info("Redis key : {} 삭제 성공", pageType);
+                    } else {
+                        log.info("Redis key : {} 삭제 실패", pageType);
+                    }
+
                     processedCount++;
                     log.debug("페이지 타입 {} 처리 완료: {} 조회수", pageType, count);
                 } catch (Exception e) {

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -1,6 +1,7 @@
 package com.example.front.pageview.scheduler;
 
 import com.example.front.pageview.entity.PageType;
+import com.example.front.pageview.entity.PageView;
 import com.example.front.pageview.repository.PageViewCountRepository;
 import com.example.front.pageview.service.PageViewCountService;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,9 @@ public class PageViewCountScheduler {
             PageType pageType = entry.getKey();
             Long count = entry.getValue();
 
-            pageViewCountRepository.saveOrUpdate(date, pageType, count);
+            PageView pageView = new PageView(new PageView.Pk(date, pageType), count);
+
+            pageViewCountRepository.save(pageView);
             pageViewCountService.deleteViewCount(pageType);
         }
     }

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -21,7 +21,7 @@ public class PageViewCountScheduler {
     private final PageViewCountService pageViewCountService;
     private final PageViewCountRepository pageViewCountRepository;
 
-    @Scheduled(cron = "0 10 11 * * *")
+    @Scheduled(cron = "0 5 0 * * *")
     @Transactional
     public void syncViewCountToDB() {
         try {

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -21,7 +21,7 @@ public class PageViewCountScheduler {
     private final PageViewCountService pageViewCountService;
     private final PageViewCountRepository pageViewCountRepository;
 
-    @Scheduled(cron = "0 10 45 * * *")
+    @Scheduled(cron = "0 50 10 * * *")
     @Transactional
     public void syncViewCountToDB() {
         try {

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -21,7 +21,7 @@ public class PageViewCountScheduler {
     private final PageViewCountService pageViewCountService;
     private final PageViewCountRepository pageViewCountRepository;
 
-    @Scheduled(cron = "0 50 10 * * *")
+    @Scheduled(cron = "0 10 11 * * *")
     @Transactional
     public void syncViewCountToDB() {
         try {

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -21,7 +21,7 @@ public class PageViewCountScheduler {
     private final PageViewCountService pageViewCountService;
     private final PageViewCountRepository pageViewCountRepository;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 25 14 * * *")
     @Transactional
     public void syncViewCountToDB() {
         try {
@@ -49,7 +49,7 @@ public class PageViewCountScheduler {
                         pageViewCountRepository.save(new PageView(pk, count));
                     }
 
-                    pageViewCountService.deleteViewCount(pageType);
+//                    pageViewCountService.deleteViewCount(pageType);
                     processedCount++;
                     log.debug("페이지 타입 {} 처리 완료: {} 조회수", pageType, count);
                 } catch (Exception e) {

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -21,7 +21,7 @@ public class PageViewCountScheduler {
     private final PageViewCountService pageViewCountService;
     private final PageViewCountRepository pageViewCountRepository;
 
-    @Scheduled(cron = "0 40 14 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void syncViewCountToDB() {
         try {
@@ -49,7 +49,7 @@ public class PageViewCountScheduler {
                         pageViewCountRepository.save(new PageView(pk, count));
                     }
 
-//                    pageViewCountService.deleteViewCount(pageType);
+                    pageViewCountService.deleteViewCount(pageType);
                     processedCount++;
                     log.debug("페이지 타입 {} 처리 완료: {} 조회수", pageType, count);
                 } catch (Exception e) {

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -21,7 +21,7 @@ public class PageViewCountScheduler {
     private final PageViewCountService pageViewCountService;
     private final PageViewCountRepository pageViewCountRepository;
 
-    @Scheduled(cron = "0 25 14 * * *")
+    @Scheduled(cron = "0 40 14 * * *")
     @Transactional
     public void syncViewCountToDB() {
         try {

--- a/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
+++ b/src/main/java/com/example/front/pageview/scheduler/PageViewCountScheduler.java
@@ -1,0 +1,34 @@
+package com.example.front.pageview.scheduler;
+
+import com.example.front.pageview.entity.PageType;
+import com.example.front.pageview.repository.PageViewCountRepository;
+import com.example.front.pageview.service.PageViewCountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class PageViewCountScheduler {
+    private final PageViewCountService pageViewCountService;
+    private final PageViewCountRepository pageViewCountRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void syncViewCountToDB() {
+        Map<PageType, Long> viewCounts = pageViewCountService.getAllViewCounts();
+        LocalDate date = LocalDate.now().minusDays(1);
+
+        for (Map.Entry<PageType, Long> entry : viewCounts.entrySet()) {
+            PageType pageType = entry.getKey();
+            Long count = entry.getValue();
+
+            pageViewCountRepository.saveOrUpdate(date, pageType, count);
+            pageViewCountService.deleteViewCount(pageType);
+        }
+    }
+}

--- a/src/main/java/com/example/front/pageview/service/PageViewCountService.java
+++ b/src/main/java/com/example/front/pageview/service/PageViewCountService.java
@@ -51,9 +51,11 @@ public class PageViewCountService {
         return result;
     }
 
-    public void deleteViewCount(PageType pageType) {
+    public boolean deleteViewCount(PageType pageType) {
         String key = getKey(pageType);
-        redisTemplate.delete(key);
+        Boolean result = redisTemplate.delete(key);
+
+        return Boolean.TRUE.equals(result);
     }
 
     private String getKey(PageType pageType) {

--- a/src/main/java/com/example/front/pageview/service/PageViewCountService.java
+++ b/src/main/java/com/example/front/pageview/service/PageViewCountService.java
@@ -4,12 +4,14 @@ import com.example.front.pageview.entity.PageType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PageViewCountService {
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -18,6 +20,7 @@ public class PageViewCountService {
         redisTemplate.opsForValue().increment(key);
     }
 
+    @Transactional(readOnly = true)
     public long getViewCount(PageType pageType) {
         String key = "view:" + pageType.getValue();
         String value = redisTemplate.opsForValue().get(key);
@@ -25,6 +28,7 @@ public class PageViewCountService {
         return value == null ? 0 : Long.parseLong(value);
     }
 
+    @Transactional(readOnly = true)
     public Map<PageType, Long> getAllViewCounts() {
         Map<PageType, Long> result = new HashMap<>();
         for (PageType pageType : PageType.values()) {

--- a/src/main/java/com/example/front/pageview/service/PageViewCountService.java
+++ b/src/main/java/com/example/front/pageview/service/PageViewCountService.java
@@ -53,6 +53,12 @@ public class PageViewCountService {
 
     public boolean deleteViewCount(PageType pageType) {
         String key = getKey(pageType);
+        if (Boolean.FALSE.equals(redisTemplate.hasKey(key))) {
+            log.error("Redis key : {} 존재하지 않음", key);
+
+            return false;
+        }
+
         Boolean result = redisTemplate.delete(key);
 
         return Boolean.TRUE.equals(result);

--- a/src/main/java/com/example/front/pageview/service/PageViewCountService.java
+++ b/src/main/java/com/example/front/pageview/service/PageViewCountService.java
@@ -1,0 +1,41 @@
+package com.example.front.pageview.service;
+
+import com.example.front.pageview.entity.PageType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class PageViewCountService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void incrementViewCount(PageType pageType) {
+        String key = "view:" + pageType.getValue();
+        redisTemplate.opsForValue().increment(key);
+    }
+
+    public long getViewCount(PageType pageType) {
+        String key = "view:" + pageType.getValue();
+        String value = redisTemplate.opsForValue().get(key);
+
+        return value == null ? 0 : Long.parseLong(value);
+    }
+
+    public Map<PageType, Long> getAllViewCounts() {
+        Map<PageType, Long> result = new HashMap<>();
+        for (PageType pageType : PageType.values()) {
+            result.put(pageType, getViewCount(pageType));
+        }
+
+        return result;
+    }
+
+    public void deleteViewCount(PageType pageType) {
+        String key = "view:" + pageType.getValue();
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/example/front/pageview/service/PageViewCountService.java
+++ b/src/main/java/com/example/front/pageview/service/PageViewCountService.java
@@ -1,13 +1,17 @@
 package com.example.front.pageview.service;
 
+import com.example.front.pageview.dto.response.PageViewGetResponse;
 import com.example.front.pageview.entity.PageType;
+import com.example.front.pageview.repository.PageViewCountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -17,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 @Transactional
 public class PageViewCountService {
     private final RedisTemplate<String, String> redisTemplate;
+    private final PageViewCountRepository pageViewCountRepository;
 
     public void incrementViewCount(PageType pageType) {
         String key = getKey(pageType);
@@ -62,6 +67,11 @@ public class PageViewCountService {
         Boolean result = redisTemplate.delete(key);
 
         return Boolean.TRUE.equals(result);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PageViewGetResponse> getPageViewByDate(LocalDate date) {
+        return pageViewCountRepository.findByPk_ViewDate(date);
     }
 
     private String getKey(PageType pageType) {

--- a/src/main/java/com/example/front/user/controller/UserController.java
+++ b/src/main/java/com/example/front/user/controller/UserController.java
@@ -1,0 +1,54 @@
+package com.example.front.user.controller;
+
+import com.example.front.pageview.entity.PageType;
+import com.example.front.pageview.service.PageViewCountService;
+import com.example.front.user.entity.User;
+import com.example.front.user.entity.UserRole;
+import com.example.front.user.service.UserService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Map;
+
+@Controller
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+    private final PageViewCountService pageViewCountService;
+
+    @GetMapping("/login")
+    public String getLoginPage() {
+        return "admin/login";
+    }
+
+    @GetMapping("/admin")
+    public String getAdminPage(HttpSession session, Model model) {
+        User user = (User) session.getAttribute("loginUser");
+        if (user != null && UserRole.ADMIN != user.getRole()) {
+            return "redirect:/login";
+        }
+
+        Map<PageType, Long> viewCounts = pageViewCountService.getAllViewCounts();
+        model.addAttribute("viewCounts", viewCounts);
+
+        return "admin/home";
+    }
+
+    @PostMapping("/login")
+    public String requestLogin(@RequestParam String id, @RequestParam String password, HttpSession session) {
+        User user = userService.login(id, password);
+        if (user == null) {
+            return "redirect:/login";
+        }
+
+        session.setAttribute("loginUser", user);
+        return "admin/home";
+    }
+}

--- a/src/main/java/com/example/front/user/controller/UserController.java
+++ b/src/main/java/com/example/front/user/controller/UserController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
 
-@Slf4j
 @Controller
 @RequestMapping("/admin")
 @RequiredArgsConstructor
@@ -28,24 +27,20 @@ public class UserController {
 
     @GetMapping("/login")
     public String getLoginPage() {
-        log.info("getLoginPage()");
         return "admin/login";
     }
 
     @GetMapping("/logout")
     public String logout(HttpSession session) {
         session.invalidate();
-        log.info("logout()");
 
         return "redirect:/admin";
     }
 
     @GetMapping("")
     public String getAdminPage(HttpSession session, Model model) {
-        log.info("getAdminPage()");
         User user = (User) session.getAttribute("loginUser");
         if (user == null || UserRole.ADMIN != user.getRole()) {
-            log.info("redirect:/admin/login");
             return "redirect:/admin/login";
         }
 
@@ -57,20 +52,17 @@ public class UserController {
 
     @PostMapping("/login")
     public String requestLogin(@RequestParam String id, @RequestParam String password, HttpSession session, HttpServletRequest request) {
-        log.info("requestLogin()");
         session.invalidate();
         session = request.getSession(true);
 
         User user = userService.login(id, password);
         if (user == null) {
-            log.info("redirect:/admin/login");
             return "redirect:/admin/login";
         }
 
         session.setAttribute("loginUser", user);
         session.setMaxInactiveInterval(600);
 
-        log.info("redirect:/admin");
         return "redirect:/admin";
     }
 }

--- a/src/main/java/com/example/front/user/controller/UserController.java
+++ b/src/main/java/com/example/front/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.example.front.pageview.service.PageViewCountService;
 import com.example.front.user.entity.User;
 import com.example.front.user.entity.UserRole;
 import com.example.front.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -49,7 +50,10 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public String requestLogin(@RequestParam String id, @RequestParam String password, HttpSession session) {
+    public String requestLogin(@RequestParam String id, @RequestParam String password, HttpSession session, HttpServletRequest request) {
+        session.invalidate();
+        session = request.getSession(true);
+
         User user = userService.login(id, password);
         if (user == null) {
             return "redirect:/admin/login";
@@ -58,6 +62,6 @@ public class UserController {
         session.setAttribute("loginUser", user);
         session.setMaxInactiveInterval(600);
 
-        return "admin/home";
+        return "redirect:/admin";
     }
 }

--- a/src/main/java/com/example/front/user/controller/UserController.java
+++ b/src/main/java/com/example/front/user/controller/UserController.java
@@ -8,7 +8,6 @@ import com.example.front.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/example/front/user/controller/UserController.java
+++ b/src/main/java/com/example/front/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.example.front.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
 
+@Slf4j
 @Controller
 @RequestMapping("/admin")
 @RequiredArgsConstructor
@@ -26,20 +28,24 @@ public class UserController {
 
     @GetMapping("/login")
     public String getLoginPage() {
+        log.info("getLoginPage()");
         return "admin/login";
     }
 
     @GetMapping("/logout")
     public String logout(HttpSession session) {
         session.invalidate();
+        log.info("logout()");
 
         return "redirect:/admin";
     }
 
     @GetMapping("")
     public String getAdminPage(HttpSession session, Model model) {
+        log.info("getAdminPage()");
         User user = (User) session.getAttribute("loginUser");
         if (user == null || UserRole.ADMIN != user.getRole()) {
+            log.info("redirect:/admin/login");
             return "redirect:/admin/login";
         }
 
@@ -51,17 +57,20 @@ public class UserController {
 
     @PostMapping("/login")
     public String requestLogin(@RequestParam String id, @RequestParam String password, HttpSession session, HttpServletRequest request) {
+        log.info("requestLogin()");
         session.invalidate();
         session = request.getSession(true);
 
         User user = userService.login(id, password);
         if (user == null) {
+            log.info("redirect:/admin/login");
             return "redirect:/admin/login";
         }
 
         session.setAttribute("loginUser", user);
         session.setMaxInactiveInterval(600);
 
+        log.info("redirect:/admin");
         return "redirect:/admin";
     }
 }

--- a/src/main/java/com/example/front/user/controller/UserController.java
+++ b/src/main/java/com/example/front/user/controller/UserController.java
@@ -28,11 +28,18 @@ public class UserController {
         return "admin/login";
     }
 
-    @GetMapping("/admin")
+    @GetMapping("/logout")
+    public String logout(HttpSession session) {
+        session.invalidate();
+
+        return "redirect:/admin";
+    }
+
+    @GetMapping("")
     public String getAdminPage(HttpSession session, Model model) {
         User user = (User) session.getAttribute("loginUser");
         if (user != null && UserRole.ADMIN != user.getRole()) {
-            return "redirect:/login";
+            return "redirect:/admin/login";
         }
 
         Map<PageType, Long> viewCounts = pageViewCountService.getAllViewCounts();
@@ -45,10 +52,12 @@ public class UserController {
     public String requestLogin(@RequestParam String id, @RequestParam String password, HttpSession session) {
         User user = userService.login(id, password);
         if (user == null) {
-            return "redirect:/login";
+            return "redirect:/admin/login";
         }
 
         session.setAttribute("loginUser", user);
+        session.setMaxInactiveInterval(600);
+
         return "admin/home";
     }
 }

--- a/src/main/java/com/example/front/user/controller/UserController.java
+++ b/src/main/java/com/example/front/user/controller/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
     @GetMapping("")
     public String getAdminPage(HttpSession session, Model model) {
         User user = (User) session.getAttribute("loginUser");
-        if (user != null && UserRole.ADMIN != user.getRole()) {
+        if (user == null || UserRole.ADMIN != user.getRole()) {
             return "redirect:/admin/login";
         }
 

--- a/src/main/java/com/example/front/user/entity/User.java
+++ b/src/main/java/com/example/front/user/entity/User.java
@@ -1,0 +1,28 @@
+package com.example.front.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long userId;
+
+    @Column(name = "user_id")
+    private String id;
+
+    @Column(name = "user_password")
+    private String password;
+
+    @Column(name = "user_role")
+    private UserRole role;
+
+}

--- a/src/main/java/com/example/front/user/entity/UserRole.java
+++ b/src/main/java/com/example/front/user/entity/UserRole.java
@@ -1,0 +1,24 @@
+package com.example.front.user.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+    ADMIN("admin"),
+    USER("user");
+
+    private String value;
+
+    UserRole(String value) {
+        this.value = value;
+    }
+
+    public static UserRole fromValue(String value) {
+        for (UserRole userRole : UserRole.values()) {
+            if (userRole.getValue().equals(value)) {
+                return userRole;
+            }
+        }
+        throw new IllegalArgumentException("Unknown value: " + value);
+    }
+}

--- a/src/main/java/com/example/front/user/entity/UserRoleConverter.java
+++ b/src/main/java/com/example/front/user/entity/UserRoleConverter.java
@@ -1,0 +1,17 @@
+package com.example.front.user.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class UserRoleConverter implements AttributeConverter<UserRole, String> {
+    @Override
+    public String convertToDatabaseColumn(UserRole attribute) {
+        return attribute == null ? null : attribute.getValue();
+    }
+
+    @Override
+    public UserRole convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : UserRole.fromValue(dbData);
+    }
+}

--- a/src/main/java/com/example/front/user/repository/UserRepository.java
+++ b/src/main/java/com/example/front/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.front.user.repository;
+
+import com.example.front.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByIdAndPassword(String id, String password);
+}

--- a/src/main/java/com/example/front/user/service/UserService.java
+++ b/src/main/java/com/example/front/user/service/UserService.java
@@ -1,0 +1,18 @@
+package com.example.front.user.service;
+
+import com.example.front.user.entity.User;
+import com.example.front.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User login(String id, String password) {
+        return userRepository.findByIdAndPassword(id, password).orElse(null);
+    }
+}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,8 +1,15 @@
-logging.level.root = INFO
+logging.level.root=INFO
 logging.file.name=/resource.log
-
 server.address=0.0.0.0
 server.port=8080
 
-com.example.front.config.back.address = ${AI_MODEL_SERVER}
-com.example.front.config.back.webhook_url = ${WEBHOOK_URL}
+com.example.front.config.back.address=${AI_MODEL_SERVER}
+com.example.front.config.back.webhook_url=${WEBHOOK_URL}
+
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USER_NAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -9,7 +9,7 @@ com.example.front.config.back.webhook_url=${WEBHOOK_URL}
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 
-spring.datasource.url=${DB_URL}
+spring.datasource.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/ggiiig
 spring.datasource.username=${DB_USER_NAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -13,3 +13,4 @@ spring.datasource.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/ggiiig
 spring.datasource.username=${DB_USER_NAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,3 +1,0 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/test_db
-spring.datasource.username=root
-spring.datasource.password=1234

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/test_db
+spring.datasource.username=root
+spring.datasource.password=1234

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,4 +19,4 @@ file.max-size = 10MB
 file.max-count = 10
 file.supported-types=image/png,image/jpeg,image/jpg
 
-app.mode=async
+app.mode=sync

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,4 +19,4 @@ file.max-size = 10MB
 file.max-count = 10
 file.supported-types=image/png,image/jpeg,image/jpg
 
-app.mode=sync
+app.mode=async

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -1,10 +1,79 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
+<html lang="ko"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{common/layout/layout}"
+      layout:fragment="content">
 
+<style>
+    @media (max-width: 600px) {
+        input[type="file"] {
+            width: 80%;
+        }
+    }
+</style>
+
+<body>
+<div>
+    <p>유용준이 원하는 오늘의 조회수</p>
+    <table>
+        <tr>
+            <th>Page Type</th>
+            <th>View Count</th>
+        </tr>
+        <tr th:each="entry : ${viewCounts}">
+            <td th:text="${entry.key}"></td>
+            <td th:text="${entry.value}"></td>
+        </tr>
+    </table>
+</div>
+
+<div>
+    <h2>날짜별 페이지 조회수 조회</h2>
+    <label for="dateInput">날짜 선택:</label>
+    <input type="date" id="dateInput" name="dateInput">
+    <button id="searchBtn">조회</button>
+
+    <div id="resultArea" style="margin-top:20px;">
+        <!-- 결과가 여기에 표시됩니다 -->
+    </div>
+
+    <script>
+        $(document).ready(function() {
+            $('#searchBtn').click(function() {
+                const selectedDate = $('#dateInput').val();
+                if (!selectedDate) {
+                    alert('날짜를 선택하세요!');
+                    return;
+                }
+
+                $.ajax({
+                    url: '/api/pageview',
+                    type: 'GET',
+                    data: { date: selectedDate },
+                    success: function(data) {
+                        let html = '';
+                        if (data.length === 0) {
+                            html = '<p>해당 날짜의 조회수 데이터가 없습니다.</p>';
+                        } else {
+                            html = '<table border="1"><tr><th>페이지 타입</th><th>조회수</th></tr>';
+                            data.forEach(function(data) {
+                                html += '<tr>';
+                                html += '<td>' + data.pk.pageType + '</td>';
+                                html += '<td>' + data.viewCount + '</td>';
+                                html += '</tr>';
+                            });
+                            html += '</table>';
+                        }
+                        $('#resultArea').html(html);
+                    },
+                    error: function(xhr) {
+                        alert('조회 중 오류가 발생했습니다: ' + xhr.responseText);
+                    }
+                });
+            });
+        });
+    </script>
+</div>
 </body>
+
 </html>

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -34,9 +34,9 @@
 
 <body>
 <!-- 로그아웃 버튼 -->
-<a href="/admin/logout">
-    <button type="button" class="logout-btn">로그아웃</button>
-</a>
+<form action="/admin/logout" method="post" style="display: inline;">
+    <button type="submit" class="logout-btn">로그아웃</button>
+</form>
 
 <div>
     <p>유용준이 원하는 오늘의 조회수</p>

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -10,6 +10,7 @@
             width: 80%;
         }
     }
+
     /* 로그아웃 버튼 스타일 (상단 우측 고정) */
     .logout-btn {
         position: absolute;
@@ -25,6 +26,7 @@
         transition: background 0.2s;
         z-index: 100;
     }
+
     .logout-btn:hover {
         background: #c62828;
     }
@@ -61,8 +63,8 @@
     </div>
 
     <script>
-        $(document).ready(function() {
-            $('#searchBtn').click(function() {
+        $(document).ready(function () {
+            $('#searchBtn').click(function () {
                 const selectedDate = $('#dateInput').val();
                 if (!selectedDate) {
                     alert('날짜를 선택하세요!');
@@ -72,25 +74,28 @@
                 $.ajax({
                     url: '/api/pageview',
                     type: 'GET',
-                    data: { date: selectedDate },
-                    success: function(data) {
+                    data: {date: selectedDate},
+                    headers: {
+                        'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                    },
+                    success: function (data) {
                         let html = '';
                         if (data.length === 0) {
                             html = '<p>해당 날짜의 조회수 데이터가 없습니다.</p>';
                         } else {
                             html = '<table border="1"><tr><th>페이지 타입</th><th>조회수</th></tr>';
-                            data.forEach(function(data) {
+                            data.forEach(function (data) {
                                 html += '<tr>';
-                                html += '<td>' + data.pk.pageType + '</td>';
-                                html += '<td>' + data.viewCount + '</td>';
+                                html += '<td>' + $('<div>').text(data.pk.pageType).html() + '</td>';
+                                html += '<td>' + $('<div>').text(data.viewCount).html() + '</td>';
                                 html += '</tr>';
                             });
                             html += '</table>';
                         }
                         $('#resultArea').html(html);
                     },
-                    error: function(xhr) {
-                        alert('조회 중 오류가 발생했습니다: ' + xhr.responseText);
+                    error: function (xhr) {
+                        alert('조회 중 오류가 발생했습니다: 관리자에게 문의하세요.');
                     }
                 });
             });

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -10,9 +10,32 @@
             width: 80%;
         }
     }
+    /* 로그아웃 버튼 스타일 (상단 우측 고정) */
+    .logout-btn {
+        position: absolute;
+        top: 20px;
+        right: 30px;
+        padding: 8px 18px;
+        background: #f44336;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        font-size: 1em;
+        cursor: pointer;
+        transition: background 0.2s;
+        z-index: 100;
+    }
+    .logout-btn:hover {
+        background: #c62828;
+    }
 </style>
 
 <body>
+<!-- 로그아웃 버튼 -->
+<a href="/admin/logout">
+    <button type="button" class="logout-btn">로그아웃</button>
+</a>
+
 <div>
     <p>유용준이 원하는 오늘의 조회수</p>
     <table>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{common/layout/layout}"
+      layout:fragment="content">
+
+<style>
+    @media (max-width: 600px) {
+        input[type="file"] {
+            width: 80%;
+        }
+    }
+</style>
+
+<body>
+<div>
+    <form action="/login" method="post">
+        <input type="text" name="id" placeholder="ID"/>
+        <input type="password" name="password" placeholder="Password"/>
+        <button type="submit">로그인</button>
+    </form>
+</div>
+</body>
+
+</html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -14,7 +14,7 @@
 
 <body>
 <div>
-    <form action="/login" method="post">
+    <form action="/admin/login" method="post">
         <input type="text" name="id" placeholder="ID"/>
         <input type="password" name="password" placeholder="Password"/>
         <button type="submit">로그인</button>

--- a/src/main/resources/templates/common/layout/layout.html
+++ b/src/main/resources/templates/common/layout/layout.html
@@ -11,6 +11,7 @@
           integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
     <title>끼이익</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <style>
         /* 헤더 색상 변경 */
         header {

--- a/src/test/java/com/example/front/FrontApplicationTests.java
+++ b/src/test/java/com/example/front/FrontApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.front;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class FrontApplicationTests {
 
 	@Test

--- a/src/test/java/com/example/front/FrontApplicationTests.java
+++ b/src/test/java/com/example/front/FrontApplicationTests.java
@@ -2,10 +2,8 @@ package com.example.front;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
 class FrontApplicationTests {
 
 	@Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> #43 

## 📝작업 내용

> Redis 에 조회수 저장 매일 00시에 DB 로 옮기는 작업


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 페이지별 방문자 수 집계 기능이 추가되었습니다.
    - Redis 및 MySQL 연동이 도입되어 데이터 저장 및 캐싱이 가능합니다.
    - 페이지 방문 통계가 매일 자동으로 데이터베이스에 동기화됩니다.
    - 관리자 로그인 및 권한 관리 기능이 추가되었습니다.
    - 관리자 페이지에서 날짜별 방문자 통계를 조회할 수 있습니다.
    - 스케줄러가 도입되어 방문자 수를 정기적으로 저장합니다.

- **설정 및 환경**
    - Redis와 MySQL 관련 환경설정이 추가 및 개선되었습니다.
    - 프로덕션 환경 및 CI/CD 파이프라인에 Redis와 MySQL 설정이 반영되었습니다.
    - 스케줄링 기능이 활성화되었습니다.

- **UI/UX 개선**
    - 관리자 페이지에 방문자 통계 대시보드가 새롭게 추가되었습니다.
    - 관리자 로그인 페이지가 새롭게 추가되었습니다.

- **버그 수정/스타일**
    - 설정 파일 내 불필요한 공백이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->